### PR TITLE
Update SQLite/SQLCipher to include recommended fixes for Xcode 12

### DIFF
--- a/Sources/SQLite/Core/Connection.swift
+++ b/Sources/SQLite/Core/Connection.swift
@@ -587,7 +587,7 @@ public final class Connection {
         var flags = SQLITE_UTF8
         #if !os(Linux)
         if deterministic {
-            flags |= SQLITE_DETERMINISTIC
+            flags |= SQLite.SQLITE_DETERMINISTIC
         }
         #endif
         sqlite3_create_function_v2(handle, function, Int32(argc), flags, unsafeBitCast(box, to: UnsafeMutableRawPointer.self), { context, argc, value in

--- a/Sources/SQLiteObjc/include/SQLiteObjc.h
+++ b/Sources/SQLiteObjc/include/SQLiteObjc.h
@@ -26,7 +26,7 @@
 #if defined(SQLITE_SWIFT_STANDALONE)
 @import sqlite3;
 #else
-@import SQLite3;
+@import SQLCipher.sqlite3;
 #endif
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
Required changes to bump up the Xcode version to Xcode 12.

Currently this repo doesn't build solo, and requires it to be brought into a project (currently HearsayMessages).

This was determined to be okay to allow us to build on Xcode 12, if it becomes a problem, we should address it in a future PR